### PR TITLE
fix abs for new golang

### DIFF
--- a/abs.go
+++ b/abs.go
@@ -6,14 +6,5 @@ package math32
 //	Abs(±Inf) = +Inf
 //	Abs(NaN) = NaN
 func Abs(x float32) float32 {
-	if x < 0 {
-		return -x
-	}
-	if x == 0 {
-		return 0 // return correctly abs(-0)
-	}
-	return x
-
-	// asUint := Float32bits(x) & uint32(0x7FFFFFFF)
-	// return Float32frombits(asUint)
+	return Float32frombits(Float32bits(x) &^ (1 << 31))
 }


### PR DESCRIPTION
Now that go is faster and better at inlining, we can use the code that looks like math.Abs