### PR TITLE
[enhancement] Added a stub to compile to ARCH wasm

### DIFF
--- a/stubs_wasm.s
+++ b/stubs_wasm.s
@@ -1,0 +1,17 @@
+// Copyright 2018 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+#include "textflag.h"
+
+TEXT ·Exp(SB),NOSPLIT,$0
+	JMP ·exp(SB)
+
+TEXT ·Log(SB),NOSPLIT,$0
+	JMP ·log(SB)
+
+TEXT ·Remainder(SB),NOSPLIT,$0
+	JMP ·remainder(SB)
+
+TEXT ·Sqrt(SB),NOSPLIT,$0
+	JMP ·sqrt(SB)


### PR DESCRIPTION
The functions:

* Exp
* Log
* Remainder
* Sqrt

Are using the pure go implementation when compiled with a GOARCH=wasm
and GOOS=js