### PR TITLE
asm: add stubs for non-amd64 arch

### DIFF
--- a/all_test.go
+++ b/all_test.go
@@ -2133,20 +2133,6 @@ func TestHypot(t *testing.T) {
 	}
 }
 
-func TestHypotGo(t *testing.T) {
-	for i := 0; i < len(vf); i++ {
-		a := Abs(1e20 * tanh[i] * Sqrt(2))
-		if f := HypotGo(1e20*tanh[i], 1e20*tanh[i]); !veryclose(a, f) {
-			t.Errorf("HypotGo(%g, %g) = %g, want %g", 1e20*tanh[i], 1e20*tanh[i], f, a)
-		}
-	}
-	for i := 0; i < len(vfhypotSC); i++ {
-		if f := HypotGo(vfhypotSC[i][0], vfhypotSC[i][1]); !alike(hypotSC[i], f) {
-			t.Errorf("HypotGo(%g, %g) = %g, want %g", vfhypotSC[i][0], vfhypotSC[i][1], f, hypotSC[i])
-		}
-	}
-}
-
 func TestIlogb(t *testing.T) {
 	for i := 0; i < len(vf); i++ {
 		a := frexp[i].i - 1 // adjust because fr in the interval [½, 1)
@@ -2801,12 +2787,6 @@ func BenchmarkGamma(b *testing.B) {
 func BenchmarkHypot(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		Hypot(3, 4)
-	}
-}
-
-func BenchmarkHypotGo(b *testing.B) {
-	for i := 0; i < b.N; i++ {
-		HypotGo(3, 4)
 	}
 }
 

--- a/exp_stub.s
+++ b/exp_stub.s
@@ -1,0 +1,7 @@
+// +build !amd64
+
+#include "textflag.h"
+
+// func Exp(x float32) float32
+TEXT ·Exp(SB),NOSPLIT,$0
+	JMP ·exp(SB)

--- a/log_stub.s
+++ b/log_stub.s
@@ -1,0 +1,7 @@
+// +build !amd64
+
+#include "textflag.h"
+
+// func Log(x float64) float64
+TEXT ·Log(SB),NOSPLIT,$0
+	JMP ·log(SB)

--- a/remainder_stub.s
+++ b/remainder_stub.s
@@ -1,0 +1,6 @@
+// +build !amd64
+
+#include "textflag.h"
+
+TEXT ·Remainder(SB),NOSPLIT,$0
+	JMP ·remainder(SB)

--- a/sqrt_stub.s
+++ b/sqrt_stub.s
@@ -1,0 +1,7 @@
+// +build !amd64
+
+#include "textflag.h"
+
+// func Sqrt(x float32) float32
+TEXT ·Sqrt(SB),NOSPLIT,$0
+	JMP ·sqrt(SB)


### PR DESCRIPTION
Added assembly stubs that call the pure go versions of functions for all
non-amd64 architectures.  Removed tests for non-existant HypotGo
function.

Updates #1