### PR TITLE
feat: add riscv64 stubs file

### DIFF
--- a/stubs_risc64.s
+++ b/stubs_risc64.s
@@ -1,0 +1,17 @@
+#include "textflag.h"
+
+// func Exp(x float32) float32
+TEXT ·Exp(SB),NOSPLIT,$0
+	B ·exp(SB)
+
+
+// func Log(x float64) float64
+TEXT ·Log(SB),NOSPLIT,$0
+	B ·log(SB)
+
+TEXT ·Remainder(SB),NOSPLIT,$0
+	B ·remainder(SB)
+
+// func Sqrt(x float32) float32
+TEXT ·Sqrt(SB),NOSPLIT,$0
+	B ·sqrt(SB)


### PR DESCRIPTION
Hello, I add the stubs for riscv64. This is not an urgent patch because it is not offically supported by upstram go.