### PR TITLE
asin,acos,atan: replace glibc with Go reference

### DIFF
--- a/acos.go
+++ b/acos.go
@@ -1,64 +1,9 @@
 package math32
 
+// Acos returns the arccosine, in radians, of x.
+//
+// Special case is:
+//	Acos(x) = NaN if x < -1 or x > 1
 func Acos(x float32) float32 {
-	const (
-		pio2_hi = Pi / 2
-		pio2_lo = -4.37113900018624283e-8
-
-		pS0 = 1.6666667163e-01  // 0x3e2aaaab
-		pS1 = -3.2556581497e-01 // 0xbea6b090
-		pS2 = 2.0121252537e-01  // 0x3e4e0aa8
-		pS3 = -4.0055535734e-02 // 0xbd241146
-		pS4 = 7.9153501429e-04  // 0x3a4f7f04
-		pS5 = 3.4793309169e-05  // 0x3811ef08
-		qS1 = -2.4033949375e+00 // 0xc019d139
-		qS2 = 2.0209457874e+00  // 0x4001572d
-		qS3 = -6.8828397989e-01 // 0xbf303361
-		qS4 = 7.7038154006e-02  // 0x3d9dc62e
-	)
-	var z, p, q, r, w, s, c, df float32
-	hx := float32ibits(x)
-	ix := hx & 0x7fffffff
-
-	if ix == 0x3f800000 { // |x|==1
-		if hx > 0 {
-			return 0.0 // acos(1) = 0
-		} else {
-			return Pi + 2*pio2_lo // acos(-1)= pi
-		}
-	} else if ix > 0x3f800000 { //|x| >= 1
-		return (x - x) / (x - x) // acos(|x|>1) is NaN
-	}
-
-	if ix < 0x3f000000 { // |x| < 0.5
-		if ix <= 0x32800000 {
-			return pio2_hi + pio2_lo //if|x|<=2**-26
-		}
-		z = x * x
-		p = z * (pS0 + z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))))
-		q = 1 + z*(qS1+z*(qS2+z*(qS3+z*qS4)))
-		r = p / q
-		return pio2_hi - (x - (pio2_lo - x*r))
-	} else if hx < 0 { // x < -0.5
-		z = (1 + x) * 0.5
-		p = z * (pS0 + z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))))
-		q = 1 + z*(qS1+z*(qS2+z*(qS3+z*qS4)))
-		s = Sqrt(z)
-		r = p / q
-		w = r*s - pio2_lo
-		return Pi - 2*(s+w)
-	} else { // x > 0.5
-		z = (1 - x) * 0.5
-		s = Sqrt(z)
-		df = s
-		idf := float32ibits(df)
-		msk := 0xfffff000
-		df = float32fromibits(idf & int32(msk))
-		c = (z - df*df) / (s + df)
-		p = z * (pS0 + z*(pS1+z*(pS2+z*(pS3+z*(pS4+z*pS5)))))
-		q = 1 + z*(qS1+z*(qS2+z*(qS3+z*qS4)))
-		r = p / q
-		w = r*s + c
-		return 2 * (df + w)
-	}
+	return Pi/2 - Asin(x)
 }

--- a/asin.go
+++ b/asin.go
@@ -1,60 +1,27 @@
 package math32
 
 func Asin(x float32) float32 {
-	const (
-		huge    = 1e30
-		pio2_hi = Pi / 2
-		pio2_lo = -4.37113900018624283e-8
-		pio4_hi = Pi / 4
-		p0      = 1.666675248e-1
-		p1      = 7.495297643e-2
-		p2      = 4.547037598e-2
-		p3      = 2.417951451e-2
-		p4      = 4.216630880e-2
-	)
-
-	hx := float32ibits(x)
-	ix := hx & 0x7fffffff
-	if ix == 0x3f800000 {
-		// asin(1)=+-pi/2 with inexact
-		return x*pio2_hi + x*pio2_lo
-	} else if ix > 0x3f800000 { // |x|>= 1
-		// asin(|x|>1) is NaN
-		return (x - x) / (x - x)
-	} else if ix < 0x3f000000 { //|x|<0.5
-		if ix < 0x32000000 { // if |x| < 2**-27
-			// math_check_force_underflow(x)
-			if huge+x > 1 {
-				// return x with inexact if x!=0
-				return x
-			}
-		} else {
-			t := x * x
-			w := t * (p0 + t*(p1+t*(p2+t*(p3+t*p4))))
-			return x + x*w
-		}
+	if x == 0 {
+		return x // special case
+	}
+	sign := false
+	if x < 0 {
+		x = -x
+		sign = true
+	}
+	if x > 1 {
+		return NaN() // special case
 	}
 
-	// 1> |x|>= 0.5
-	w := 1 - Abs(x)
-	t := w * 0.5
-	p := t * (p0 + t*(p1+t*(p2+t*(p3+t*p4))))
-	s := Sqrt(t)
-	if ix >= 0x3F79999A { /* if |x| > 0.975 */
-		t = pio2_hi - (2.0*(s+s*p) - pio2_lo)
+	temp := Sqrt(1 - x*x)
+	if x > 0.7 {
+		temp = Pi/2 - satan(temp/x)
 	} else {
-		w = s
-		iw := float32ibits(w)
-		msk := 0xfffff000
-		w = float32fromibits(iw & int32(msk))
-		c := (t - w*w) / (s + w)
-		r := p
-		p = 2*s*r - (pio2_lo - 2*c)
-		q := pio4_hi - 2*w
-		t = pio4_hi - (p - q)
+		temp = satan(x / temp)
 	}
-	if hx > 0 {
-		return t
+
+	if sign {
+		temp = -temp
 	}
-	return -t
+	return temp
 }

--- a/atan.go
+++ b/atan.go
@@ -1,7 +1,90 @@
 package math32
 
-import "math"
-
 func Atan(x float32) float32 {
-	return float32(math.Atan(float64(x)))
+	if x == 0 {
+		return x
+	}
+	if x > 0 {
+		return satan(x)
+	}
+	return -satan(-x)
+}
+
+// The original C code, the long comment, and the constants below were
+// from http://netlib.sandia.gov/cephes/cmath/atan.c, available from
+// http://www.netlib.org/cephes/cmath.tgz.
+// The go code is a version of the original C.
+//
+// atan.c
+// Inverse circular tangent (arctangent)
+//
+// SYNOPSIS:
+// double x, y, atan();
+// y = atan( x );
+//
+// DESCRIPTION:
+// Returns radian angle between -pi/2 and +pi/2 whose tangent is x.
+//
+// Range reduction is from three intervals into the interval from zero to 0.66.
+// The approximant uses a rational function of degree 4/5 of the form
+// x + x**3 P(x)/Q(x).
+//
+// ACCURACY:
+//                      Relative error:
+// arithmetic   domain    # trials  peak     rms
+//    DEC       -10, 10   50000     2.4e-17  8.3e-18
+//    IEEE      -10, 10   10^6      1.8e-16  5.0e-17
+//
+// Cephes Math Library Release 2.8:  June, 2000
+// Copyright 1984, 1987, 1989, 1992, 2000 by Stephen L. Moshier
+//
+// The readme file at http://netlib.sandia.gov/cephes/ says:
+//    Some software in this archive may be from the book _Methods and
+// Programs for Mathematical Functions_ (Prentice-Hall or Simon & Schuster
+// International, 1989) or from the Cephes Mathematical Library, a
+// commercial product. In either event, it is copyrighted by the author.
+// What you see here may be used freely but it comes with no support or
+// guarantee.
+//
+//   The two known misprints in the book are repaired here in the
+// source listings for the gamma function and the incomplete beta
+// integral.
+//
+//   Stephen L. Moshier
+//   moshier@na-net.ornl.gov
+
+// xatan evaluates a series valid in the range [0, 0.66].
+func xatan(x float32) float32 {
+	const (
+		P0 = -8.750608600031904122785e-01
+		P1 = -1.615753718733365076637e+01
+		P2 = -7.500855792314704667340e+01
+		P3 = -1.228866684490136173410e+02
+		P4 = -6.485021904942025371773e+01
+		Q0 = +2.485846490142306297962e+01
+		Q1 = +1.650270098316988542046e+02
+		Q2 = +4.328810604912902668951e+02
+		Q3 = +4.853903996359136964868e+02
+		Q4 = +1.945506571482613964425e+02
+	)
+	z := x * x
+	z = z * ((((P0*z+P1)*z+P2)*z+P3)*z + P4) / (((((z+Q0)*z+Q1)*z+Q2)*z+Q3)*z + Q4)
+	z = x*z + x
+	return z
+}
+
+// satan reduces its argument (known to be positive)
+// to the range [0, 0.66] and calls xatan.
+func satan(x float32) float32 {
+	const (
+		Morebits float32 = 6.123233995736765886130e-17 // pi/2 = PIO2 + Morebits
+		Tan3pio8 float32 = 2.41421356237309504880      // tan(3*pi/8)
+	)
+	if x <= 0.66 {
+		return xatan(x)
+	}
+	if x > Tan3pio8 {
+		return Pi/2 - xatan(1/x) + Morebits
+	}
+	return Pi/4 + xatan((x-1)/(x+1)) + 0.5*Morebits
 }


### PR DESCRIPTION
A friend of mine warned me about restricive licenses recently and sure enough, the `glibc` reference I used had the LGPL license, a quite restrictive license. So I replaced the source with Go stdlib version which uses permissive BSD license. Also added `atan` implementation.