### PR TITLE
sqrt stubs fixed. usable in tinygo now!

### DIFF
--- a/export_test.go
+++ b/export_test.go
@@ -3,6 +3,6 @@ package math32
 // Export internal functions for testing.
 
 // var Exp2Go = exp2
-var SqrtGo = sqrt
+var SqrtGo = noarchsqrt
 var ExpGo = exp
 var HypotGo = hypot

--- a/sqrt.go
+++ b/sqrt.go
@@ -1,9 +1,14 @@
 package math32
 
-func Sqrt(x float32) float32
+func Sqrt(x float32) float32 {
+	if haveArchSqrt {
+		return archSqrt(x)
+	}
+	return noarchsqrt(x)
+}
 
 // TODO: add assembly for !build noasm
-func sqrt(x float32) float32 {
+func noarchsqrt(x float32) float32 {
 	// special cases
 	switch {
 	case x == 0 || IsNaN(x) || IsInf(x, 1):

--- a/sqrt_amd64.s
+++ b/sqrt_amd64.s
@@ -1,7 +1,7 @@
 #include "textflag.h"
 
-// func Sqrt(x float32) float32
-TEXT ·Sqrt(SB),NOSPLIT,$0
+// func archSqrt(x float32) float32
+TEXT ·archSqrt(SB),NOSPLIT,$0
 	MOVSS x+0(FP), X0
 	SQRTSS X0, X0
 	MOVSS X0, ret+8(FP)

--- a/sqrt_arm64.s
+++ b/sqrt_arm64.s
@@ -4,8 +4,8 @@
 
 #include "textflag.h"
 
-// func Sqrt(x float64) float64
-TEXT ·Sqrt(SB),NOSPLIT,$0
+// func archSqrt(x float32) float32
+TEXT ·archSqrt(SB),NOSPLIT,$0
 	FMOVS	x+0(FP), F0
 	FSQRTS	F0, F0
 	FMOVS	F0, ret+8(FP)

--- a/sqrt_asm.go
+++ b/sqrt_asm.go
@@ -1,0 +1,13 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build !noasm && (386 || amd64 || arm64 || arm || ppc64le || s390x || riscv64 || wasm)
+// +build !noasm
+// +build 386 amd64 arm64 arm ppc64le s390x riscv64 wasm
+
+package math32
+
+const haveArchSqrt = true
+
+func archSqrt(x float32) float32

--- a/sqrt_noasm.go
+++ b/sqrt_noasm.go
@@ -1,0 +1,14 @@
+// Copyright 2021 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+//go:build noasm || (!386 && !amd64 && !arm64 && !arm && !ppc64le && !s390x && !riscv64 && !wasm)
+// +build noasm !386,!amd64,!arm64,!arm,!ppc64le,!s390x,!riscv64,!wasm
+
+package math32
+
+const haveArchSqrt = false
+
+func archSqrt(x float32) float32 {
+	panic("not implemented")
+}

--- a/stubs_386.s
+++ b/stubs_386.s
@@ -16,6 +16,6 @@ TEXT ·Log(SB),NOSPLIT,$0
 TEXT ·Remainder(SB),NOSPLIT,$0
 	JMP ·remainder(SB)
 
-// func Sqrt(x float32) float32
-TEXT ·Sqrt(SB),NOSPLIT,$0
+// func archSqrt(x float32) float32
+TEXT ·archSqrt(SB),NOSPLIT,$0
 	JMP ·sqrt(SB)

--- a/stubs_arm.s
+++ b/stubs_arm.s
@@ -16,6 +16,6 @@ TEXT ·Log(SB),NOSPLIT,$0
 TEXT ·Remainder(SB),NOSPLIT,$0
 	B ·remainder(SB)
 
-// func Sqrt(x float32) float32
-TEXT ·Sqrt(SB),NOSPLIT,$0
+// func archSqrt(x float32) float32
+TEXT ·archSqrt(SB),NOSPLIT,$0
 	B ·sqrt(SB)

--- a/stubs_arm64.s
+++ b/stubs_arm64.s
@@ -1,6 +1,6 @@
 #include "textflag.h"
 
-// func Log(x float64) float64
+// func archLog(x float64) float64
 TEXT ·Log(SB),NOSPLIT,$0
 	B ·log(SB)
 

--- a/stubs_ppc64le.s
+++ b/stubs_ppc64le.s
@@ -16,6 +16,6 @@ TEXT ·Log(SB),NOSPLIT,$0
 TEXT ·Remainder(SB),NOSPLIT,$0
 	JMP ·remainder(SB)
 
-// func Sqrt(x float32) float32
-TEXT ·Sqrt(SB),NOSPLIT,$0
+// func archSqrt(x float32) float32
+TEXT ·archSqrt(SB),NOSPLIT,$0
 	JMP ·sqrt(SB)

--- a/stubs_risc64.s
+++ b/stubs_risc64.s
@@ -18,6 +18,6 @@ TEXT ·Log(SB),NOSPLIT,$0
 TEXT ·Remainder(SB),NOSPLIT,$0
 	B ·remainder(SB)
 
-// func Sqrt(x float32) float32
-TEXT ·Sqrt(SB),NOSPLIT,$0
+// func archSqrt(x float32) float32
+TEXT ·archSqrt(SB),NOSPLIT,$0
 	B ·sqrt(SB)

--- a/stubs_s390x.s
+++ b/stubs_s390x.s
@@ -12,6 +12,6 @@ TEXT ·Log(SB),NOSPLIT,$0
 TEXT ·Remainder(SB),NOSPLIT,$0
 	BR ·remainder(SB)
 
-// func Sqrt(x float32) float32
-TEXT ·Sqrt(SB),NOSPLIT,$0
+// func archSqrt(x float32) float32
+TEXT ·archSqrt(SB),NOSPLIT,$0
 	BR ·sqrt(SB)

--- a/stubs_wasm.s
+++ b/stubs_wasm.s
@@ -18,6 +18,6 @@ TEXT ·Log(SB),NOSPLIT,$0
 TEXT ·Remainder(SB),NOSPLIT,$0
 	JMP ·remainder(SB)
 
-// func Sqrt(x float32) float32
-TEXT ·Sqrt(SB),NOSPLIT,$0
+// func archSqrt(x float32) float32
+TEXT ·archSqrt(SB),NOSPLIT,$0
 	JMP ·sqrt(SB)


### PR DESCRIPTION
I'm going to be guarding pesky uses of assembly behind build tags so that math32 can be built on any architecture, particularily for use in TinyGo!