### PR TITLE
fix recursive ARM asm call to remainder; match archRemainder for ARM64

### DIFF
--- a/stubs_arm.s
+++ b/stubs_arm.s
@@ -14,7 +14,7 @@ TEXT ·archLog(SB),NOSPLIT,$0
 
 // func archRemainder(x, y float32) float32
 TEXT ·archRemainder(SB),NOSPLIT,$0
-	B ·archRemainder(SB)
+	B ·remainder(SB)
 
 // func archSqrt(x float32) float32
 TEXT ·archSqrt(SB),NOSPLIT,$0

--- a/stubs_arm64.s
+++ b/stubs_arm64.s
@@ -4,6 +4,6 @@
 TEXT ·archLog(SB),NOSPLIT,$0
 	B ·log(SB)
 
-// func archRemainder(x float32) float32 // TODO
+// func archRemainder(x, y float32) float32 // TODO
 // TEXT ·archRemainderTODO(SB),NOSPLIT,$0
 //	B ·remainder(SB)


### PR DESCRIPTION
@chewxy can I get a review on this? Found a bug in arm stubs and a possible bug in the arm64 stub, both for the remainder instruction.

Closes #47 